### PR TITLE
Quick start fixes

### DIFF
--- a/pvoutput/consts.py
+++ b/pvoutput/consts.py
@@ -1,9 +1,9 @@
 import os
 from datetime import timedelta
-
+from urllib.parse import urljoin
 
 BASE_URL = 'https://pvoutput.org'
-MAP_URL = os.path.join(BASE_URL, 'map.jsp')
+MAP_URL = urljoin(BASE_URL, 'map.jsp')
 
 # Country codes used by PVOutput.org on, for example,
 # https://pvoutput.org/map.jsp.  Taken from

--- a/pvoutput/pvoutput.py
+++ b/pvoutput/pvoutput.py
@@ -85,6 +85,8 @@ class PVOutput:
                     'data_service_url', config_filename)
             except KeyError:
                 pass
+            except FileNotFoundError:
+                pass
 
         if self.data_service_url is not None:
             if not self.data_service_url.strip('/').endswith('.org'):

--- a/pvoutput/pvoutput.py
+++ b/pvoutput/pvoutput.py
@@ -9,6 +9,7 @@ import requests
 import tables
 import numpy as np
 import pandas as pd
+from urllib.parse import urljoin
 
 from pvoutput.exceptions import NoStatusFound, RateLimitExceeded
 from pvoutput.utils import _get_response, _get_param_from_config_file
@@ -818,8 +819,7 @@ class PVOutput:
             'X-Pvoutput-Apikey': self.api_key,
             'X-Pvoutput-SystemId': self.system_id}
 
-        api_url = os.path.join(
-            BASE_URL, 'service/r2/{}.jsp'.format(service))
+        api_url = urljoin(BASE_URL, 'service/r2/{}.jsp'.format(service))
 
         return _get_response(api_url, api_params, headers)
 

--- a/pvoutput/pvoutput.py
+++ b/pvoutput/pvoutput.py
@@ -842,7 +842,7 @@ class PVOutput:
         api_params['key'] = self.api_key
         api_params['sid'] = self.system_id
 
-        api_url = os.path.join(
+        api_url = urljoin(
             self.data_service_url, 'service/r2/{}.jsp'.format(service))
 
         return _get_response(api_url, api_params, headers)

--- a/pvoutput/tests/test_pvoutput.py
+++ b/pvoutput/tests/test_pvoutput.py
@@ -8,15 +8,13 @@ def test_convert_consecutive_dates_to_date_ranges():
     missing_dates = dr1 + dr2
     date_ranges = pvoutput._convert_consecutive_dates_to_date_ranges(
         missing_dates)
-
+    columns = ['missing_start_date_PV_localtime',
+               'missing_end_date_PV_localtime']
     pd.testing.assert_frame_equal(
-        date_ranges,
+        date_ranges[columns],
         pd.DataFrame(
             [
                 [dr1[0], dr1[-1]],
                 [dr2[0], dr2[-1]],
             ],
-            columns=[
-                'missing_start_date_PV_localtime',
-                'missing_end_date_PV_localtime'
-            ]))
+            columns=columns))


### PR DESCRIPTION
Hi, I was encountering similar errors to that as described in #38 , running on Windows. The first part was that I hadn't created the pvoutput.yml and also hadn't specified data_service_url. I think as the code was written, both of those were not truly optional. 

The second point which took me a while to spot, was that the os.path.join on Windows was putting a double // inbetween  '.org' and 'service'. When this is parsed to the API, you get a really unhelpful 404 error if you look in the browser console with this error displayed on page "The page you requested is missing or has an error." 

Using urllib's urljoin solved this problem. I haven't tested this in Linux.  

I think hazaioud ran into problems with the Python code appearing to freeze due to all the Retries. Reducing the number of Retries to one stops the code from appearing to hang.