### PR TITLE
Fixing map

### DIFF
--- a/pvoutput/consts.py
+++ b/pvoutput/consts.py
@@ -4,6 +4,7 @@ from urllib.parse import urljoin
 
 BASE_URL = 'https://pvoutput.org'
 MAP_URL = urljoin(BASE_URL, 'map.jsp')
+REGIONS_URL = urljoin(BASE_URL, 'region.jsp')
 
 # Country codes used by PVOutput.org on, for example,
 # https://pvoutput.org/map.jsp.  Taken from

--- a/pvoutput/mapscraper.py
+++ b/pvoutput/mapscraper.py
@@ -45,23 +45,25 @@ def get_pv_systems_for_country(
 
     country_code = _convert_to_country_code(country)
     regions = [region] if region else get_regions_for_country(country_code)
-    #TODO LOOP THROUGH REGIONS HRE
     all_metadata = []
-    for page_number in range(max_pages):
-        print('\rReading page {:2d}'.format(page_number), end='', flush=True)
-        #TODO pass region in here
-        url = _create_map_url(
-            country_code=country_code,
-            page_number=page_number,
-            ascending=ascending,
-            sort_by=sort_by,
-            region=region)
-        soup = get_soup(url)
-        metadata = _process_metadata(soup)
-        all_metadata.append(metadata)
+    for region in regions:
+        for page_number in range(max_pages):
+            print('\rReading page {:2d} for region: {}'.format(page_number, region), end='', flush=True)
+            url = _create_map_url(
+                country_code=country_code,
+                page_number=page_number,
+                ascending=ascending,
+                sort_by=sort_by,
+                region=region)
+            soup = get_soup(url)
+            if _page_is_blank(soup):
+                break
+            metadata = _process_metadata(soup)
+            metadata['region'] = region
+            all_metadata.append(metadata)
 
-        if not _page_has_next_link(soup):
-            break
+            if not _page_has_next_link(soup):
+                break
 
     return pd.concat(all_metadata)
 
@@ -178,7 +180,6 @@ def _process_metadata(soup: BeautifulSoup,
 def _process_system_size_col(soup: BeautifulSoup) -> pd.DataFrame:
     pv_system_size_col = soup.find_all(
         'a', href=re.compile('display\.jsp\?sid='))
-
     metadata = []
     for row in pv_system_size_col:
         metadata_for_row = {}
@@ -243,7 +244,7 @@ def _remove_str_and_convert_to_numeric(
 
 def _convert_metadata_cols_to_numeric(df: pd.DataFrame) -> pd.DataFrame:
     for col_name, string_to_remove in [
-            ('array_tilt_degrees', '°'),
+            #('array_tilt_degrees', '°'),
             ('capacity_kW', 'kW'),
             ('average_efficiency_kWh_per_kW', 'kWh/kW')]:
         df[col_name] = _remove_str_and_convert_to_numeric(
@@ -274,7 +275,9 @@ def _convert_energy_to_numeric_watt_hours(series: pd.Series) -> pd.Series:
 def _process_generation_and_average_cols(
         soup: BeautifulSoup,
         index: Optional[Iterable] = None) -> pd.DataFrame:
-    generation_and_average_cols = soup.find_all(text=re.compile('\d[Mk]Wh$'))
+    _soup = copy(soup)
+    [s.decompose() for s in _soup.select('a')]
+    generation_and_average_cols = _soup.find_all(text=re.compile('\d[Mk]Wh$'))
     generation_col = generation_and_average_cols[0::2]
     average_col = generation_and_average_cols[1::2]
     df = pd.DataFrame(
@@ -296,6 +299,13 @@ def _process_efficiency_col(
     efficiency_col = soup.find_all(text=re.compile('\dkWh/kW'))
     return pd.Series(
         efficiency_col, name='average_efficiency_kWh_per_kW', index=index)
+
+
+def _page_is_blank(soup: BeautifulSoup) -> bool:
+    #Pages can still be blank even if the previous page has a Next Button
+    pv_system_size_col = soup.find_all(
+        'a', href=re.compile('display\.jsp\?sid='))
+    return not bool(pv_system_size_col)
 
 
 def get_soup(url, raw=False, parser='html.parser'):
@@ -329,8 +339,8 @@ def get_regions_for_country(country_code: int):
         'a', href=re.compile('map\.jsp\?country='))
     for row in region_tags:
         href = row.attrs['href']
-        p = re.compile('^map\.jsp\?country=243&region=(\w+\s*\w+)$')
+        p = re.compile('^map\.jsp\?country=243&region=(\w+.*)$')
         href_match = p.match(href)
         region = href_match.group(1)
-        region_list.append(1)
+        region_list.append(region)
     return region_list


### PR DESCRIPTION
The map page seems to have changed. If you don't specify a region it only shows you one region for that country e.g. Belfast when you pass the current url for the UK. So to get all the panels for a country you have to loop through the regions too.

I have added functionality to get the regions for a country, or the user can specify their own. 

Some sites have two configurations of panels with different orientation and angles. When these columns are turned into numeric columns it causes issues. I have commented out the part where this occurs. An alternative could be to create two rows when this occurs and modify the capacity accordingly. But both rows would have the same site ID
![two_set_of_panels](https://user-images.githubusercontent.com/39378848/104108693-a1fe6600-52be-11eb-8af3-429202a31147.PNG)
