### PR TITLE
Issue #61

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ api_key: <API key from PVOutput.org>
 system_id: <SystemID from PVOutput.org>
 ```
 
+The default location of the `.pvoutput.yml` is the user's home directory, expanded from `~`. This can be overridden by setting the `PVOUTPUT_CONFIG` environment variable.
+
+e.g. `export PVOUTPUT_CONFIG="/my/preferred/location/.pvoutput.yml"`
+
 ### API quotas and paid subscriptions
 
 * For free, PVOutput.org gives you 60 API requests per hour.  Per request, you can download one day of data for one PV system.  (See PVOutput's docs for more info about [rate limits](https://pvoutput.org/help/api_specification.html#rate-limits).)

--- a/pvoutput/consts.py
+++ b/pvoutput/consts.py
@@ -284,7 +284,7 @@ PV_OUTPUT_MAP_COLUMN_NAMES = {
 ONE_DAY = timedelta(days=1)
 
 PV_OUTPUT_DATE_FORMAT = "%Y%m%d"
-CONFIG_FILENAME = os.path.expanduser("~/.pvoutput.yml")
+CONFIG_FILENAME = os.environ.get("PVOUTPUT_CONFIG", os.path.expanduser("~/.pvoutput.yml"))
 RATE_LIMIT_PARAMS_TO_API_HEADERS = {
     "rate_limit_remaining": "X-Rate-Limit-Remaining",
     "rate_limit_total": "X-Rate-Limit-Limit",


### PR DESCRIPTION
When loading config, check first if PVOUTPUT_CONFIG env var is set, and if so load from that location rather then the default

# Pull Request

## Description

Useful feature if running inside Docker container.

Fixes #61 

## How Has This Been Tested?

Tested by running inside a Docker container with config file mounted in a non-default location (`/`) and setting `-e PVOUTPUT_CONFIG=/.pvoutput.yml`

- [ ] No
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
