### PR TITLE
Small fixes to allow querying US data

### DIFF
--- a/pvoutput/mapscraper.py
+++ b/pvoutput/mapscraper.py
@@ -292,6 +292,7 @@ def _convert_energy_to_numeric_watt_hours(series: pd.Series) -> pd.Series:
     for unit, multiplier in [("kWh", 1e3), ("MWh", 1e6)]:
         selection = series[series.str.contains(unit)]
         selection = selection.str.replace(unit, "")
+        selection = selection.str.replace(",", "")
         selection = pd.to_numeric(selection)
         selection *= multiplier
         data.append(selection)
@@ -376,7 +377,7 @@ def get_regions_for_country(country_code: int):
     region_tags = soup.find_all("a", href=re.compile(r"map\.jsp\?country="))
     for row in region_tags:
         href = row.attrs["href"]
-        p = re.compile(r"^map\.jsp\?country=243&region=(\w+.*)$")
+        p = re.compile(r"^map\.jsp\?country=" + str(country_code) + r"&region=(\w+.*)$")
         href_match = p.match(href)
         region = href_match.group(1)
         region_list.append(region)


### PR DESCRIPTION
# Pull Request

## Description

The UK country code was hard-coded into one location. Some data in the US is apparently reported using commas (e.g. `1,381.46W`) which was confusing the parser. Both are one-line fixes below.

## How Has This Been Tested?

Note that this is a bugfix. I ran some of the code in `quick_start.ipynb` (with modifications for the US) and it seems to work. There are likely other fixes needed, though, querying in the US directly (using `pv.search`) still doesn't work properly.