### PR TITLE
fix: Use tz_convert for timezone-aware rate_limit_reset_time #123

### DIFF
--- a/pvoutput/pvoutput.py
+++ b/pvoutput/pvoutput.py
@@ -1050,7 +1050,11 @@ class PVOutput:
             setattr(self, param_name, header_value)
 
         self.rate_limit_reset_time = pd.Timestamp.utcfromtimestamp(self.rate_limit_reset_time)
-        self.rate_limit_reset_time = self.rate_limit_reset_time.tz_localize("utc")
+        # Fix for Issue #123: Handle both naive and aware timestamps
+        if self.rate_limit_reset_time.tzinfo is None:
+           self.rate_limit_reset_time = self.rate_limit_reset_time.tz_localize("utc")
+        else:
+           self.rate_limit_reset_time = self.rate_limit_reset_time.tz_convert("utc")
 
         _LOG.debug("%s", self.rate_limit_info())
 

--- a/pvoutput/pvoutput.py
+++ b/pvoutput/pvoutput.py
@@ -1052,9 +1052,9 @@ class PVOutput:
         self.rate_limit_reset_time = pd.Timestamp.utcfromtimestamp(self.rate_limit_reset_time)
         # Fix for Issue #123: Handle both naive and aware timestamps
         if self.rate_limit_reset_time.tzinfo is None:
-           self.rate_limit_reset_time = self.rate_limit_reset_time.tz_localize("utc")
+            self.rate_limit_reset_time = self.rate_limit_reset_time.tz_localize("utc")
         else:
-           self.rate_limit_reset_time = self.rate_limit_reset_time.tz_convert("utc")
+            self.rate_limit_reset_time = self.rate_limit_reset_time.tz_convert("utc")
 
         _LOG.debug("%s", self.rate_limit_info())
 


### PR DESCRIPTION
## Description

Fixes #123

This PR resolves a `TypeError` where `tz_localize` was being called on already timezone-aware timestamps.

**The Fix:**
I updated `pvoutput.py` to check `tzinfo` before assigning a timezone:
- Uses `tz_localize("utc")` if the timestamp is naive.
- Uses `tz_convert("utc")` if the timestamp is already aware.

## How Has This Been Tested?

I validated the logic against the reported traceback and standard Pandas documentation. I could not run the full notebook locally due to missing API keys (`FileNotFoundError`), but this is a standard fix for this specific Pandas error.

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings