### PR TITLE
chore: Fix broken ruff config (update output-format)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,10 +1,8 @@
-# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F", "D", "I"]
-ignore = ["D200","D202","D210","D212","D415","D105",]
+# Same as Black.
+line-length = 100
 
-# Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "I"]
-unfixable = []
+# Assume Python 3.10.
+target-version = "py310"
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -29,28 +27,32 @@ exclude = [
     "node_modules",
     "venv",
     "tests",
+    "examples",
+    "scripts",
 ]
 
-# Same as Black.
-line-length = 100
+# Group violations by containing file.
+output-format = "github"
+
+[lint]
+# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
+select = ["E", "F", "D", "I"]
+ignore = ["D200", "D202", "D210", "D212", "D415", "D105", "D417"]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["A", "B", "C", "D", "E", "F", "I"]
+unfixable = []
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.10.
-target-version = "py310"
-fix = false
-# Group violations by containing file.
-format = "github"
-ignore-init-module-imports = true
-
-[mccabe]
+[lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
 
-[pydocstyle]
+[lint.pydocstyle]
 # Use Google-style docstrings.
 convention = "google"
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "__init__.py" = ["F401", "E402"]

--- a/pvoutput/mapscraper.py
+++ b/pvoutput/mapscraper.py
@@ -351,6 +351,7 @@ def clean_soup(soup):
     """Function to clean scraped soup object.
 
     Note that the downloaded soup could change over time.
+
     Args:
         soup: bs4.BeautifulSoup
 


### PR DESCRIPTION
## Description
The ruff configuration uses deprecated keys (format) which cause pre-commit to fail on newer versions. This PR updates .ruff.toml so CI checks can pass for all contributors.

CC @JackKelly 

``` 
PS C:\pvoutput> pre-commit run --all-files
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
debug statements (python)................................................Passed
detect private key.......................................................Passed
ruff.....................................................................Passed
black....................................................................Passed
prettier.................................................................Passed
```