### PR TITLE
Fix invalid Ruff output format causing CI failure

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -53,3 +53,4 @@ convention = "google"
 
 [lint.per-file-ignores]
 "__init__.py" = ["F401", "E402"]
+"setup.py" = ["D100"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -31,9 +31,6 @@ exclude = [
     "scripts",
 ]
 
-# Group violations by containing file.
-output-format = "github"
-
 [lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 select = ["E", "F", "D", "I"]


### PR DESCRIPTION
## Description

Fixes a CI failure caused by an invalid Ruff configuration.

The repository was using `output-format = "github"` in `.ruff.toml`, which is no longer supported by recent versions of Ruff and causes config parsing to fail before linting runs.

This change removes the invalid option, allowing Ruff to run successfully and restoring CI.

Related to the issue discussed in PR #132.

## How Has This Been Tested?

- CI (Ruff pre-commit hook)

- [x] Yes

_If your changes affect data processing, have you plotted any changes?_

- [x] N/A (tooling / configuration change only)

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
