### PR TITLE
refactor: replace deprecated parse_dates usage

### DIFF
--- a/pvoutput/pvoutput.py
+++ b/pvoutput/pvoutput.py
@@ -271,10 +271,15 @@ class PVOutput:
             StringIO(pv_system_status_text),
             lineterminator=";",
             names=["date", "time"] + columns,
-            parse_dates={"datetime": ["date", "time"]},
-            index_col=["datetime"],
             dtype={col: np.float64 for col in columns},
-        ).sort_index()
+        )
+        pv_system_status["datetime"] = pd.to_datetime(
+            pv_system_status["date"].astype(str) + " " + pv_system_status["time"].astype(str),
+            format="%Y%m%d %H:%M",
+        )
+        pv_system_status = (
+            pv_system_status.drop(columns=["date", "time"]).set_index("datetime").sort_index()
+        )
 
         # add timezone
         if timezone is not None:
@@ -511,9 +516,10 @@ class PVOutput:
                 "secondary_orientation",
                 "secondary_array_tilt_degrees",
             ],
-            parse_dates=["install_date"],
             nrows=1,
-        ).squeeze()
+        )
+        pv_metadata["install_date"] = pd.to_datetime(pv_metadata["install_date"])
+        pv_metadata = pv_metadata.squeeze()
         pv_metadata["system_id"] = pv_system_id
         pv_metadata.name = pv_system_id
         return pv_metadata
@@ -588,8 +594,10 @@ class PVOutput:
             StringIO(pv_metadata_text),
             names=columns,
             dtype={col: np.float32 for col in numeric_cols},
-            parse_dates=date_cols,
         )
+        for col in date_cols:
+            pv_metadata[col] = pd.to_datetime(pv_metadata[col])
+
         if pv_metadata.empty:
             data = {col: np.float32(np.NaN) for col in numeric_cols}
             data.update({col: pd.NaT for col in date_cols})

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ shapely
 cython>0.15.1
 geopandas
 pytest
+pytest-mock
 pyyaml
 tables
 matplotlib

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -84,9 +84,8 @@ datetime,cumulative_energy_gen_Wh,instantaneous_power_gen_W,temperature_C,voltag
 2014-03-30 08:00:00,24.0,132.0,,"""
 
     df = process_batch_status(response_text)
-    correct_df = pd.read_csv(
-        StringIO(correct_interpretation_csv), parse_dates=["datetime"], index_col="datetime"
-    )
+    correct_df = pd.read_csv(StringIO(correct_interpretation_csv), index_col="datetime")
+    correct_df.index = pd.to_datetime(correct_df.index)
     pd.testing.assert_frame_equal(df, correct_df)
 
     empty_df = process_batch_status("")

--- a/tests/test_pvoutput.py
+++ b/tests/test_pvoutput.py
@@ -100,3 +100,117 @@ def test_check_pv_system_status():
     bad_timeseries2 = _make_timeseries("2019-01-02 00:00", "2019-01-03 00:00")
     with pytest.raises(ValueError):
         pvoutput.check_pv_system_status(bad_timeseries2, DATE)
+
+
+def test_read_csv_calls_do_not_use_deprecated_parse_dates(monkeypatch):
+    pv = pvoutput.PVOutput(api_key="fake", system_id="fake")
+
+    original_read_csv = pd.read_csv
+    parse_dates_values = []
+
+    def wrapped_read_csv(*args, **kwargs):
+        if "parse_dates" in kwargs:
+            parse_dates_values.append(kwargs["parse_dates"])
+        return original_read_csv(*args, **kwargs)
+
+    monkeypatch.setattr(pd, "read_csv", wrapped_read_csv)
+
+    api_responses = {
+        "getstatus": "20220301,08:00,2,3,4,5,6,7,8;20220301,07:45,1,2,3,4,5,6,7",
+        "getsystem": (
+            "System Name,5000,Address,10,500,PanelBrand,1,5000,InverterBrand,180,30,None,"
+            "2020-01-01,-0.1,51.5,5,0,0,0,0"
+        ),
+        "getstatistic": "100,10,5,1,9,2,30,2022-01-01,2022-01-31,3,2022-01-15",
+    }
+
+    def fake_api_query(service, api_params, **kwargs):
+        return api_responses[service]
+
+    monkeypatch.setattr(pv, "_api_query", fake_api_query)
+
+    pv.get_status(pv_system_id=1, date="20220301", historic=False)
+    pv.get_metadata(pv_system_id=1)
+    pv.get_statistic(pv_system_id=1, date_from="20220101", date_to="20220131")
+
+    assert not parse_dates_values
+
+
+def test_get_status_datetime_index_contract(monkeypatch):
+    pv = pvoutput.PVOutput(api_key="fake", system_id="fake")
+
+    def fake_api_query(service, api_params, **kwargs):
+        assert service == "getstatus"
+        return "20220301,08:00,2,3,4,5,6,7,8;20220301,07:45,1,2,3,4,5,6,7"
+
+    monkeypatch.setattr(pv, "_api_query", fake_api_query)
+
+    result = pv.get_status(pv_system_id=1, date="20220301", historic=False)
+
+    assert isinstance(result.index, pd.DatetimeIndex)
+    assert result.index.name == "datetime"
+    assert result.index.is_monotonic_increasing
+    assert result.index[0] == pd.Timestamp("2022-03-01 07:45:00")
+    assert result.index[-1] == pd.Timestamp("2022-03-01 08:00:00")
+    assert "date" not in result.columns
+    assert "time" not in result.columns
+    assert "datetime" not in result.columns
+
+
+def test_get_status_timezone_conversion_contract(monkeypatch):
+    pv = pvoutput.PVOutput(api_key="fake", system_id="fake")
+
+    def fake_api_query(service, api_params, **kwargs):
+        assert service == "getstatus"
+        return "20220101,07:45,1,2,3,4,5,6,7"
+
+    monkeypatch.setattr(pv, "_api_query", fake_api_query)
+
+    result = pv.get_status(
+        pv_system_id=1,
+        date="20220101",
+        historic=False,
+        timezone="Europe/London",
+    )
+
+    assert isinstance(result.index, pd.DatetimeIndex)
+    assert result.index.name == "datetime"
+    assert result.index.tz is not None
+    assert result.index[0].utcoffset() == pd.Timedelta(0)
+
+
+def test_get_metadata_install_date_type_contract(monkeypatch):
+    pv = pvoutput.PVOutput(api_key="fake", system_id="fake")
+
+    def fake_api_query(service, api_params, **kwargs):
+        assert service == "getsystem"
+        return (
+            "System Name,5000,Address,10,500,PanelBrand,1,5000,InverterBrand,180,30,None,"
+            "2020-01-01,-0.1,51.5,5,0,0,0,0"
+        )
+
+    monkeypatch.setattr(pv, "_api_query", fake_api_query)
+
+    result = pv.get_metadata(pv_system_id=123)
+
+    assert isinstance(result["install_date"], pd.Timestamp)
+    assert result["install_date"] == pd.Timestamp("2020-01-01")
+
+
+def test_get_statistic_date_columns_type_contract(monkeypatch):
+    pv = pvoutput.PVOutput(api_key="fake", system_id="fake")
+
+    def fake_api_query(service, api_params, **kwargs):
+        assert service == "getstatistic"
+        return "100,10,5,1,9,2,30,2022-01-01,2022-01-31,3,2022-01-15"
+
+    monkeypatch.setattr(pv, "_api_query", fake_api_query)
+
+    result = pv.get_statistic(pv_system_id=1, date_from="20220101", date_to="20220131")
+
+    assert pd.api.types.is_datetime64_any_dtype(result["actual_date_from"])
+    assert pd.api.types.is_datetime64_any_dtype(result["actual_date_to"])
+    assert pd.api.types.is_datetime64_any_dtype(result["record_efficiency_date"])
+    assert result.loc[1, "actual_date_from"] == pd.Timestamp("2022-01-01")
+    assert result.loc[1, "actual_date_to"] == pd.Timestamp("2022-01-31")
+    assert result.loc[1, "record_efficiency_date"] == pd.Timestamp("2022-01-15")


### PR DESCRIPTION
# Pull Request

## Description

Replace deprecated pandas `read_csv(..., parse_dates=...)` usage with explicit datetime parsing in preparation for a future pandas 3 upgrade.

This change keeps the existing parser behaviour while removing deprecated `parse_dates` usage from the production code paths covered here. In particular:
- status parsing still produces a `DatetimeIndex` named `datetime`
- metadata date fields are still parsed as datetimes
- statistic date fields are still parsed as datetimes

This PR is intentionally narrow. It removes deprecated parser usage but does not claim full pandas 3 compatibility across the full repository.

This PR also adds `pytest-mock` to `requirements.txt`.

Strictly speaking, that is a new declared dependency, but only for test execution. This repository already includes `pytest` in `requirements.txt`, and `requirements.txt` is currently used both for local development/test setup and as the package dependency source in `setup.py`. In that existing layout, adding `pytest-mock` keeps the test environment reproducible and avoids requiring a separate manual install before running the suite in a fresh environment.

This dependency change is not required by the parser refactor itself at runtime. It is included so contributors can reproduce the test runs described below using the repository's current dependency model.

Fixes #

## How Has This Been Tested?

Using the repository's `uv` workflow with the existing `.venv`:

```bash
uv pip install --python .venv/bin/python -r requirements.txt
uv pip install --python .venv/bin/python -e . pandas==2.2.3
.venv/bin/python -m pytest -q
```

Added/updated coverage verifies:
 - `read_csv` calls no longer rely on deprecated `parse_dates`
 - `get_status()` still returns a `DatetimeIndex` named `datetime`
 - timezone conversion behaviour in `get_status()` is preserved
 - metadata and statistic date fields are still returned as datetimes

full test suite: 39 passed, 2 skipped

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

I performed parser-level sanity checks through deterministic unit tests covering datetime parsing and index behaviour. No plotting was needed because this change is limited to parser behaviour rather than data transformation.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings

## Disclosure
LLM was used to help document this change, test updates, and verification steps. All changes were reviewed and validated before submission.